### PR TITLE
Expand desktop header to xl breakpoint

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -32,20 +32,20 @@ import MobileNavigation from './MobileNavigation.astro';
         </a>
       </div>
 
-      <!-- Navegación escritorio - se oculta en md (768px) -->
-      <div class="hidden md:flex items-center space-x-4 lg:space-x-6">
+      <!-- Navegación escritorio - se oculta en xl (1280px) -->
+      <div class="hidden xl:flex items-center space-x-4 2xl:space-x-6">
         <Navigation />
         
         <!-- Contacto teléfono -->
         <a 
           href="tel:+34682290381"
-          class="flex items-center space-x-2 text-sm lg:text-base font-bold text-gray-900 hover:text-red-700 transition-colors whitespace-nowrap"
+          class="flex items-center space-x-2 text-sm xl:text-base font-bold text-gray-900 hover:text-red-700 transition-colors whitespace-nowrap"
           aria-label="Llamar al 682 290 381"
         >
-          <svg class="w-4 h-4 lg:w-5 lg:h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="w-4 h-4 xl:w-5 xl:h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
           </svg>
-          <span class="hidden lg:inline">682 290 381</span>
+          <span class="hidden xl:inline">682 290 381</span>
         </a>
 
         <!-- WhatsApp - siempre visible como icono -->
@@ -56,7 +56,7 @@ import MobileNavigation from './MobileNavigation.astro';
           class="flex items-center space-x-2 text-gray-700 hover:text-green-600 transition-colors"
           aria-label="Contactar por WhatsApp"
         >
-          <svg class="w-4 h-4 lg:w-5 lg:h-5" fill="currentColor" viewBox="0 0 24 24">
+          <svg class="w-4 h-4 xl:w-5 xl:h-5" fill="currentColor" viewBox="0 0 24 24">
             <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893c0-3.176-1.24-6.165-3.495-8.411"/>
           </svg>
           <span class="hidden xl:inline">WhatsApp</span>
@@ -71,8 +71,8 @@ import MobileNavigation from './MobileNavigation.astro';
         </a>
       </div>
 
-      <!-- Controles móvil - aparece en md (768px) -->
-      <div class="flex md:hidden items-center space-x-3">
+      <!-- Controles móvil - aparece hasta xl (1280px) -->
+      <div class="flex xl:hidden items-center space-x-3">
         <!-- WhatsApp icono en móvil -->
         <a 
           href="https://wa.me/34682290381"


### PR DESCRIPTION
## Summary
- move the desktop navigation to only render at the xl breakpoint so links never overflow
- align the telephone and WhatsApp text visibility with the wider desktop breakpoint and adjust icon sizing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfaa6b637c832ca845b6d98cca6404